### PR TITLE
Merge: main <- dev

### DIFF
--- a/src/main/java/com/globeot/globeotback/global/exception/ErrorCode.java
+++ b/src/main/java/com/globeot/globeotback/global/exception/ErrorCode.java
@@ -53,7 +53,8 @@
         APPLICATION_PENDING(HttpStatus.BAD_REQUEST, "APPLICATION4007", "지원서가 아직 처리 중입니다."),
 
         // S3
-        S3_UPLOAD_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "S35001", "파일 업로드에 실패했습니다.");
+        S3_UPLOAD_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "S35001", "파일 업로드에 실패했습니다."),
+        FILE_SIZE_EXCEEDED(HttpStatus.PAYLOAD_TOO_LARGE, "FILE4131", "파일 크기가 허용 한도(30MB)를 초과했습니다.");
 
         private final HttpStatus status;
         private final String code;

--- a/src/main/java/com/globeot/globeotback/global/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/globeot/globeotback/global/exception/GlobalExceptionHandler.java
@@ -6,6 +6,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
+import org.springframework.web.multipart.MaxUploadSizeExceededException;
 import org.springframework.web.multipart.support.MissingServletRequestPartException;
 
 @RestControllerAdvice
@@ -40,6 +41,14 @@ public class GlobalExceptionHandler {
         return ResponseEntity
                 .badRequest()
                 .body(ApiResponse.onFailure("COMMON400", "필수 요청 데이터가 누락되었습니다: " + e.getRequestPartName()));
+    }
+
+    @ExceptionHandler(MaxUploadSizeExceededException.class)
+    public ResponseEntity<ApiResponse<Object>> handleMaxUploadSizeExceededException(MaxUploadSizeExceededException e) {
+        ErrorCode errorCode = ErrorCode.FILE_SIZE_EXCEEDED;
+        return ResponseEntity
+                .status(errorCode.getStatus())
+                .body(ApiResponse.onFailure(errorCode.getCode(), errorCode.getMessage()));
     }
 
     @ExceptionHandler(IllegalArgumentException.class)

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -27,8 +27,8 @@ spring:
     show-sql: true
   servlet:
     multipart:
-      max-file-size: 10MB
-      max-request-size: 30MB
+      max-file-size: 30MB
+      max-request-size: 100MB
 
 server:
   address: 0.0.0.0


### PR DESCRIPTION
## 📌 PR 개요

* 이미지 업로드 시 큰 파일을 올리면 모호한 `COMMON500("서버 내부 오류가 발생했습니다.")` 응답이 내려가던 버그 수정.

---

## ✨ 변경 사항

- `application.yaml`: `max-file-size` 10MB → 30MB, `max-request-size` 30MB → 100MB (폰 카메라 사진이 보통 5~12MB라 10MB 제한이 너무 빡빡)
- `GlobalExceptionHandler`: `MaxUploadSizeExceededException` 전용 핸들러 추가 → 413 + `FILE4131` 명확한 한글 메시지 응답
- `ErrorCode`: `FILE_SIZE_EXCEEDED(413, "FILE4131")` 추가

---

## 🔗 관련 이슈

없음 (운영 사용자 제보로 확인)

---

## 📷 테스트 / 실행 결과

로컬에서 dev 브랜치 코드로 직접 검증:

| 케이스 | 결과 |
|---|---|
| 100KB 업로드 | `200 OK` + S3 URL |
| 15MB 업로드 | `200 OK` + S3 URL (이전엔 `COMMON500`) |
| 35MB 업로드(한도 초과) | `413` + `FILE4131: "파일 크기가 허용 한도(30MB)를 초과했습니다."` (이전엔 모호한 `COMMON500`) |

---

## 📌 참고 사항

`max-file-size`를 30MB로 잡으면서 `max-request-size`도 같이 100MB로 올렸습니다 (단일 요청에 여러 파일 첨부 가능성 대비).