### PR TITLE
Merge: main <- dev

### DIFF
--- a/src/main/java/com/globeot/globeotback/community/repository/CommentRepository.java
+++ b/src/main/java/com/globeot/globeotback/community/repository/CommentRepository.java
@@ -25,4 +25,6 @@ public interface CommentRepository extends JpaRepository<Comment, Long> {
     Long countByArticle_Id(Long articleId);
 
     List<Comment> findAllByArticle_IdOrderByCreatedAtAsc(Long articleId);
+
+    boolean existsByParent_Id(Long parentId);
 }

--- a/src/main/java/com/globeot/globeotback/community/service/ArticleService.java
+++ b/src/main/java/com/globeot/globeotback/community/service/ArticleService.java
@@ -257,7 +257,15 @@ public class ArticleService {
     public void deleteComment(Long userId, Long commentId) {
         Comment comment = findComment(commentId);
         checkAuthor(userId, comment.getUser().getId());
-        commentRepository.delete(comment);
+
+        // 대댓글이 달려있으면 대화 흐름 유지를 위해 soft-delete (content만 교체)
+        if (commentRepository.existsByParent_Id(commentId)) {
+            comment.setContent("삭제된 댓글입니다.");
+            comment.setUpdatedAt(LocalDateTime.now());
+            commentRepository.save(comment);
+        } else {
+            commentRepository.delete(comment);
+        }
     }
 
     // ── 내부 헬퍼 ────────────────────────────────────────────────────────────
@@ -283,7 +291,8 @@ public class ArticleService {
 
     private void checkAuthor(Long userId, Long authorId) {
         if (!userId.equals(authorId)) {
-            throw new IllegalStateException("권한이 없습니다.");
+            throw new com.globeot.globeotback.global.exception.CustomException(
+                    com.globeot.globeotback.global.exception.ErrorCode.FORBIDDEN);
         }
     }
 

--- a/src/main/java/com/globeot/globeotback/global/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/globeot/globeotback/global/exception/GlobalExceptionHandler.java
@@ -1,13 +1,18 @@
 package com.globeot.globeotback.global.exception;
 
 import com.globeot.globeotback.global.response.ApiResponse;
+import tools.jackson.databind.exc.InvalidFormatException;
 import jakarta.servlet.http.HttpServletRequest;
 import org.springframework.http.ResponseEntity;
+import org.springframework.http.converter.HttpMessageNotReadableException;
 import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
+import org.springframework.web.method.annotation.MethodArgumentTypeMismatchException;
 import org.springframework.web.multipart.MaxUploadSizeExceededException;
 import org.springframework.web.multipart.support.MissingServletRequestPartException;
+
+import java.util.stream.Collectors;
 
 @RestControllerAdvice
 public class GlobalExceptionHandler {
@@ -49,6 +54,54 @@ public class GlobalExceptionHandler {
         return ResponseEntity
                 .status(errorCode.getStatus())
                 .body(ApiResponse.onFailure(errorCode.getCode(), errorCode.getMessage()));
+    }
+
+    @ExceptionHandler(HttpMessageNotReadableException.class)
+    public ResponseEntity<ApiResponse<Object>> handleHttpMessageNotReadable(HttpMessageNotReadableException e) {
+        String message = "요청 본문을 읽을 수 없습니다. JSON 형식을 확인해주세요.";
+
+        InvalidFormatException ife = findCause(e, InvalidFormatException.class);
+        if (ife != null && ife.getTargetType() != null && ife.getTargetType().isEnum()) {
+            String allowedValues = java.util.Arrays.stream(ife.getTargetType().getEnumConstants())
+                    .map(Object::toString)
+                    .collect(Collectors.joining(", "));
+            Object badValue = ife.getValue();
+            message = String.format("값 '%s'은(는) 유효하지 않습니다. 허용값: [%s]", badValue, allowedValues);
+        }
+
+        return ResponseEntity
+                .badRequest()
+                .body(ApiResponse.onFailure("COMMON400", message));
+    }
+
+    @SuppressWarnings("unchecked")
+    private <T extends Throwable> T findCause(Throwable e, Class<T> type) {
+        Throwable c = e;
+        while (c != null) {
+            if (type.isInstance(c)) return (T) c;
+            c = c.getCause();
+        }
+        return null;
+    }
+
+    @ExceptionHandler(MethodArgumentTypeMismatchException.class)
+    public ResponseEntity<ApiResponse<Object>> handleMethodArgumentTypeMismatch(MethodArgumentTypeMismatchException e) {
+        String paramName = e.getName();
+        String message;
+        Class<?> targetType = e.getRequiredType();
+
+        if (targetType != null && targetType.isEnum()) {
+            String allowedValues = java.util.Arrays.stream(targetType.getEnumConstants())
+                    .map(Object::toString)
+                    .collect(Collectors.joining(", "));
+            message = String.format("파라미터 '%s'의 값이 유효하지 않습니다. 허용값: [%s]", paramName, allowedValues);
+        } else {
+            message = String.format("파라미터 '%s'의 값 형식이 올바르지 않습니다.", paramName);
+        }
+
+        return ResponseEntity
+                .badRequest()
+                .body(ApiResponse.onFailure("COMMON400", message));
     }
 
     @ExceptionHandler(IllegalArgumentException.class)


### PR DESCRIPTION
## 📌 PR 개요

* 커뮤니티 API 전수 테스트 중 발견된 백엔드 이슈 4종 한 번에 정리.

---

## ✨ 변경 사항

### 1) 잘못된 enum 값 → 500 대신 400 + 명확한 메시지
- **요청 본문**: `HttpMessageNotReadableException` 핸들러 추가 (Jackson 3의 `tools.jackson.databind.exc.InvalidFormatException` 기준)
- **query/path 파라미터**: `MethodArgumentTypeMismatchException` 핸들러 추가
- enum 타입이면 허용값 목록까지 포함해 응답

### 2) 대댓글이 달린 부모 댓글 삭제 시 500 → 정상 동작
- 원인: `comments.parent_id` FK 위반으로 `DataIntegrityViolationException` 발생
- 자식 댓글이 있으면 대화 흐름 유지를 위해 **soft-delete** (content를 "삭제된 댓글입니다."로 교체)
- 자식이 없으면 기존처럼 hard-delete

### 3) 권한 거부 응답: 400 → 403
- `ArticleService.checkAuthor`가 `IllegalStateException`으로 던지던 것을 `CustomException(ErrorCode.FORBIDDEN)`으로 변경
- HTTP 시멘틱 정합성 확보

---

## 🔗 관련 이슈

없음 (커뮤니티 기능 전수 curl 테스트 중 발견)

---

## 📷 테스트 / 실행 결과

로컬 dev 브랜치 코드로 직접 검증:

| 케이스 | 변경 전 | 변경 후 |
|---|---|---|
| `type: "TRADE"` (body) | `500 COMMON500` | `400 COMMON400` "값 'TRADE'은(는) 유효하지 않습니다. 허용값: [QUESTION, INFO, SALE, COMPANION]" |
| `?type=TRADE` (query) | `500 COMMON500` | `400 COMMON400` "파라미터 'type'의 값이 유효하지 않습니다. 허용값: [...]" |
| `/articles/abc` (path) | `500 COMMON500` | `400 COMMON400` "파라미터 'articleId'의 값 형식이 올바르지 않습니다." |
| 대댓글 있는 부모 댓글 삭제 | `500 COMMON500` | `200` + content "삭제된 댓글입니다." |
| 남의 글 수정 시도 | `400 "권한이 없습니다."` | `403 COMMON403 "접근 권한이 없습니다."` |
| 정상 케이스 (회귀) | OK | OK (회귀 없음) |

---

## 📌 참고 사항

이번 PR로 닫히지 **않는** 별개 이슈 (프론트 작업 필요):
- 이미지 업로드 protocol 불일치 (프론트 base64+JSON vs 백엔드 multipart) → 프론트 `FormData` 전환 필요
- 글쓰기 "거래" 선택 시 프론트 `mapTypeToApi`가 잘못된 enum 값 `"TRADE"` 전송 (백엔드는 `"SALE"`) — 단, 이번 PR로 500 대신 400 + 명확 메시지 응답으로 개선됨
- 신고 사유를 자유 텍스트로 전송 — 백엔드는 `Reason` enum 기대 (이것도 마찬가지로 이번 PR로 메시지는 친절해짐)